### PR TITLE
Packagelist Cleanup in Installprocedure

### DIFF
--- a/bin/bootstrap-ubuntu.sh
+++ b/bin/bootstrap-ubuntu.sh
@@ -25,9 +25,6 @@ apt-get install -y \
   php$php_version-ctype \
   php$php_version-fpm \
   php$php_version-mbstring \
-  php$php_version-mysql \
-  php$php_version-mysqlnd \
-  php$php_version-mysqli \
   php$php_version-mcrypt \
   php$php_version-pdo \
   dsc22 cassandra=$cassandra_version cassandra-tools=$cassandra_version \


### PR DESCRIPTION
As far as I can tell, not a single line of code in Minds is touching MySQL anymore. `git grep -i mysql` is turning up empty on minds/minds. There appear to be some instances left in the multisite feature of minds/engine, but they are all commented out.