### PR TITLE
(#134) Added nginx-based auto-language negotiation for /.

### DIFF
--- a/containers/nginx/dev.conf
+++ b/containers/nginx/dev.conf
@@ -1,3 +1,12 @@
+# Dynamic language redirection.
+# Ensure that "en" is last, or people with, for instance, "fr en" will always default to "en".
+map $http_accept_language $lang {
+    default en;
+    ~es es;
+    ~fr fr;
+    ~en en;
+}
+
 server {
     listen 80;
     listen [::]:80 default ipv6only=on;
@@ -22,6 +31,11 @@ server {
     location / {
         try_files $uri $uri/ @rewrite;
         port_in_redirect off;
+    }
+
+    # Redirect to the language directory specified by the user's browser via the Accept-Language header.
+    location ~ ^/$ {
+        return 301 $scheme://$http_host$1/$lang/;
     }
 
     location ~ ^(/api|/fs|/icon|/carousel) {

--- a/containers/nginx/minds.conf
+++ b/containers/nginx/minds.conf
@@ -1,3 +1,12 @@
+# Dynamic language redirection.
+# Ensure that "en" is last, or people with, for instance, "fr en" will always default to "en".
+map $http_accept_language $lang {
+    default en;
+    ~es es;
+    ~fr fr;
+    ~en en;
+}
+
 server {
     listen 80;
     listen [::]:80 default ipv6only=on;
@@ -23,6 +32,11 @@ server {
     location / {
         try_files $uri $uri/ @rewrite;
         port_in_redirect off;
+    }
+
+    # Redirect to the language directory specified by the user's browser via the Accept-Language header.
+    location ~ ^/$ {
+        return 301 $scheme://$http_host$1/$lang/;
     }
 
     location ~ ^(/api|/fs|/icon|/carousel) {


### PR DESCRIPTION
**The Problem:** Upon following the directions to the letter, when I
go to http://localhost:8080/ I get a 403: Forbidden nginx error screen.

**The Reason:** No language detection / negotiation is done, and / is empty.

**The Solution:** I added nginx-based language negotiation using the browser's
`Accept-Language` header. If the user does not set a header (some search engines,
curl, etc.), it will show the English page.

This only applies to the / route. It is assumed that any other route will be in
the desired language.

Now, http://localhost:8080/ will redirect to http://localhost:8080/en/.

**IMPORTANT: You must manually remove your `minds_nginx` image and rebuild it.**

Fixes #134.